### PR TITLE
Switch from `@node-redis/client` to `@redis/client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "2.2.1",
             "license": "MIT",
             "dependencies": {
-                "@graphql-tools/merge": "^8.2.14"
+                "@graphql-tools/merge": "^8.2.14",
+                "@redis/client": "^1.5.5"
             },
             "devDependencies": {
                 "@types/cookie-parser": "^1.4.2",
@@ -25,7 +26,6 @@
             "optionalDependencies": {
                 "@apollo/server": "^4.3.0",
                 "@apollographql/graphql-playground-html": "^1.6.29",
-                "@node-redis/client": "^1.0.6",
                 "cookie-parser": "^1.4.6",
                 "cors": "^2.8.5",
                 "express": "^4.17.1",
@@ -1174,21 +1174,6 @@
             "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==",
             "optional": true
         },
-        "node_modules/@node-redis/client": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@node-redis/client/-/client-1.0.6.tgz",
-            "integrity": "sha512-SRlHlrz2xAg1o5j9ZdnoF2fA8EZydbXr1mdUv35w0O0NP3XcYt3nQ7WAtmOu13kUa90PhmVoqTDMsTereAETfg==",
-            "optional": true,
-            "dependencies": {
-                "cluster-key-slot": "1.1.0",
-                "generic-pool": "3.8.2",
-                "redis-parser": "3.0.0",
-                "yallist": "4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1287,6 +1272,19 @@
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "optional": true
+        },
+        "node_modules/@redis/client": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.5.tgz",
+            "integrity": "sha512-fuMnpDYSjT5JXR9rrCW1YWA4L8N/9/uS4ImT3ZEC/hcaQRI1D/9FvwjriRj1UvepIgzZXthFVKMNRzP/LNL7BQ==",
+            "dependencies": {
+                "cluster-key-slot": "1.1.2",
+                "generic-pool": "3.9.0",
+                "yallist": "4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@sqltools/formatter": {
             "version": "1.2.5",
@@ -1824,10 +1822,9 @@
             }
         },
         "node_modules/cluster-key-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-            "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
-            "optional": true,
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2588,10 +2585,9 @@
             "devOptional": true
         },
         "node_modules/generic-pool": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.8.2.tgz",
-            "integrity": "sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==",
-            "optional": true,
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+            "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
             "engines": {
                 "node": ">= 4"
             }
@@ -3703,27 +3699,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/redis-errors": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-            "optional": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/redis-parser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-            "optional": true,
-            "dependencies": {
-                "redis-errors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/reflect-metadata": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -4806,8 +4781,7 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "devOptional": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
             "version": "17.7.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "postversion": "git push --tags && git push"
     },
     "dependencies": {
-        "@graphql-tools/merge": "^8.2.14"
+        "@graphql-tools/merge": "^8.2.14",
+        "@redis/client": "^1.5.5"
     },
     "devDependencies": {
         "@types/cookie-parser": "^1.4.2",
@@ -33,7 +34,6 @@
     "optionalDependencies": {
         "@apollo/server": "^4.3.0",
         "@apollographql/graphql-playground-html": "^1.6.29",
-        "@node-redis/client": "^1.0.6",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.17.1",

--- a/src/modules/redis.ts
+++ b/src/modules/redis.ts
@@ -1,5 +1,5 @@
 import { AsyncContainerModule } from 'inversify';
-import { createClient } from '@node-redis/client';
+import { createClient } from '@redis/client';
 import { RedisClientService, RedisSubscriberClientService } from '../redis';
 import assert from '../util/assert';
 

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -1,4 +1,4 @@
-import type { createClient } from '@node-redis/client';
+import type { createClient } from '@redis/client';
 
 export type RedisClient = ReturnType<typeof createClient>;
 


### PR DESCRIPTION
In version `redis@4.1.0` the sub-packages were moved from the `@node-redis` scope to `@redis`.  See [here](https://github.com/redis/node-redis#packages).

